### PR TITLE
Add spirit stone tiers with tiered drops

### DIFF
--- a/main/java/com/bo/cultivatereg/client/ClientSetup.java
+++ b/main/java/com/bo/cultivatereg/client/ClientSetup.java
@@ -2,9 +2,11 @@
 package com.bo.cultivatereg.client;
 
 import com.bo.cultivatereg.CultivateReg;
-import com.bo.cultivatereg.registry.ModEntities;
+import com.bo.cultivatereg.item.SpiritStoneItem;
+import com.bo.cultivatereg.registry.ModItems;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.EntityRenderersEvent;
+import net.minecraftforge.client.event.RegisterColorHandlersEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
@@ -14,5 +16,21 @@ public class ClientSetup {
     @SubscribeEvent
     public static void onRegisterRenderers(EntityRenderersEvent.RegisterRenderers e) {
 
+    }
+
+    @SubscribeEvent
+    public static void onRegisterItemColors(RegisterColorHandlersEvent.Item e) {
+        e.register((stack, tintIndex) -> {
+            if (tintIndex != 0) return 0xFFFFFF;
+            if (stack.getItem() instanceof SpiritStoneItem stone) {
+                return stone.getColor();
+            }
+            return 0xFFFFFF;
+        },
+                ModItems.LOW_GRADE_SPIRIT_STONE.get(),
+                ModItems.SPIRIT_STONE.get(),
+                ModItems.HIGH_GRADE_SPIRIT_STONE.get(),
+                ModItems.TOP_GRADE_SPIRIT_STONE.get()
+        );
     }
 }

--- a/main/java/com/bo/cultivatereg/item/SpiritStoneItem.java
+++ b/main/java/com/bo/cultivatereg/item/SpiritStoneItem.java
@@ -1,0 +1,16 @@
+package com.bo.cultivatereg.item;
+
+import net.minecraft.world.item.Item;
+
+public class SpiritStoneItem extends Item {
+    private final int color;
+
+    public SpiritStoneItem(int color, Properties properties) {
+        super(properties);
+        this.color = color;
+    }
+
+    public int getColor() {
+        return color;
+    }
+}

--- a/main/java/com/bo/cultivatereg/loot/AddSpiritStoneModifier.java
+++ b/main/java/com/bo/cultivatereg/loot/AddSpiritStoneModifier.java
@@ -1,32 +1,102 @@
 package com.bo.cultivatereg.loot;
 
+import com.bo.cultivatereg.cultivation.MobCultivationCapability;
+import com.bo.cultivatereg.cultivation.MobCultivationData;
+import com.bo.cultivatereg.cultivation.Realm;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
 import net.minecraftforge.common.loot.IGlobalLootModifier;
 import net.minecraftforge.common.loot.LootModifier;
 
+import java.util.Optional;
+
 public class AddSpiritStoneModifier extends LootModifier {
-    private final ItemStack stack;
+    public record TierEntry(Item item, int count) {
+        public static final Codec<TierEntry> CODEC = RecordCodecBuilder.create(inst -> inst.group(
+                BuiltInRegistries.ITEM.byNameCodec().fieldOf("item").forGetter(TierEntry::item),
+                Codec.INT.fieldOf("count").forGetter(TierEntry::count)
+        ).apply(inst, TierEntry::new));
+    }
+
+    private final TierEntry low;
+    private final TierEntry mid;
+    private final TierEntry high;
+    private final TierEntry top;
+    private final float coreTopChance;
 
     public static final Codec<AddSpiritStoneModifier> CODEC = RecordCodecBuilder.create(inst ->
             LootModifier.codecStart(inst)
-                    .and(ItemStack.CODEC.fieldOf("stack").forGetter(m -> m.stack))
+                    .and(TierEntry.CODEC.fieldOf("low").forGetter(m -> m.low))
+                    .and(TierEntry.CODEC.fieldOf("mid").forGetter(m -> m.mid))
+                    .and(TierEntry.CODEC.fieldOf("high").forGetter(m -> m.high))
+                    .and(TierEntry.CODEC.fieldOf("top").forGetter(m -> m.top))
+                    .and(Codec.FLOAT.optionalFieldOf("core_top_chance", 0.05f).forGetter(m -> m.coreTopChance))
                     .apply(inst, AddSpiritStoneModifier::new)
     );
 
-    protected AddSpiritStoneModifier(LootItemCondition[] conditions, ItemStack stack) {
+    protected AddSpiritStoneModifier(
+            LootItemCondition[] conditions,
+            TierEntry low,
+            TierEntry mid,
+            TierEntry high,
+            TierEntry top,
+            float coreTopChance
+    ) {
         super(conditions);
-        this.stack = stack;
+        this.low = low;
+        this.mid = mid;
+        this.high = high;
+        this.top = top;
+        this.coreTopChance = Math.max(0.0f, coreTopChance);
     }
 
     @Override
     protected ObjectArrayList<ItemStack> doApply(ObjectArrayList<ItemStack> generatedLoot, LootContext ctx) {
-        generatedLoot.add(stack.copy());
+        Entity entity = ctx.getParamOrNull(LootContextParams.THIS_ENTITY);
+        if (!(entity instanceof LivingEntity living)) {
+            addIfPresent(generatedLoot, low);
+            return generatedLoot;
+        }
+
+        Optional<MobCultivationData> dataOpt = living.getCapability(MobCultivationCapability.CAP).resolve();
+        if (dataOpt.isEmpty() || !dataOpt.get().hasCultivation()) {
+            addIfPresent(generatedLoot, low);
+            return generatedLoot;
+        }
+
+        MobCultivationData data = dataOpt.get();
+        Realm realm = data.getRealm();
+
+        if (realm == Realm.FOUNDATION) {
+            addIfPresent(generatedLoot, mid);
+        } else if (realm == Realm.CORE_FORMATION) {
+            addIfPresent(generatedLoot, high);
+            if (coreTopChance > 0f && ctx.getRandom().nextFloat() < coreTopChance) {
+                addIfPresent(generatedLoot, top);
+            }
+        } else {
+            // Qi Gathering or anything else defaults to low tier
+            addIfPresent(generatedLoot, low);
+        }
+
         return generatedLoot;
+    }
+
+    private static void addIfPresent(ObjectArrayList<ItemStack> generatedLoot, TierEntry entry) {
+        if (entry == null) return;
+        Item item = entry.item();
+        int count = entry.count();
+        if (item == null || count <= 0) return;
+        generatedLoot.add(new ItemStack(item, count));
     }
 
     @Override

--- a/main/java/com/bo/cultivatereg/network/SenseAttemptPacket.java
+++ b/main/java/com/bo/cultivatereg/network/SenseAttemptPacket.java
@@ -30,7 +30,7 @@ public record SenseAttemptPacket(int meridianIndex) {
                 if (d.isMeridianOpen(idx)) return;
 
                 // === Attempt cost ===
-                final var SPIRIT_STONE_ID = ResourceLocation.fromNamespaceAndPath("cultivatereg", "spirit_stone");
+                final var SPIRIT_STONE_ID = ResourceLocation.fromNamespaceAndPath("cultivatereg", "low_spirit_stone");
 
                 if (d.getRealm() == Realm.MORTAL) {
                     // Mortal: must use a Spirit Stone per attempt

--- a/main/java/com/bo/cultivatereg/registry/ModItems.java
+++ b/main/java/com/bo/cultivatereg/registry/ModItems.java
@@ -1,6 +1,7 @@
 package com.bo.cultivatereg.registry;
 
 import com.bo.cultivatereg.CultivateReg;
+import com.bo.cultivatereg.item.SpiritStoneItem;
 import net.minecraft.world.item.Item;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.registries.DeferredRegister;
@@ -11,8 +12,17 @@ public class ModItems {
     public static final DeferredRegister<Item> ITEMS =
             DeferredRegister.create(ForgeRegistries.ITEMS, CultivateReg.MODID);
 
+    public static final RegistryObject<Item> LOW_GRADE_SPIRIT_STONE =
+            ITEMS.register("low_spirit_stone", () -> new SpiritStoneItem(0x8E8E8E, new Item.Properties().stacksTo(64)));
+
     public static final RegistryObject<Item> SPIRIT_STONE =
-            ITEMS.register("spirit_stone", () -> new Item(new Item.Properties().stacksTo(64)));
+            ITEMS.register("spirit_stone", () -> new SpiritStoneItem(0xFFFFFF, new Item.Properties().stacksTo(64)));
+
+    public static final RegistryObject<Item> HIGH_GRADE_SPIRIT_STONE =
+            ITEMS.register("high_spirit_stone", () -> new SpiritStoneItem(0xFF9A3C, new Item.Properties().stacksTo(64)));
+
+    public static final RegistryObject<Item> TOP_GRADE_SPIRIT_STONE =
+            ITEMS.register("top_spirit_stone", () -> new SpiritStoneItem(0xFF4A4A, new Item.Properties().stacksTo(64)));
 
     public static void register(IEventBus bus) {
         ITEMS.register(bus);

--- a/main/resources/assets/cultivatereg/lang/en_us.json
+++ b/main/resources/assets/cultivatereg/lang/en_us.json
@@ -4,7 +4,10 @@
   "key.cultivatereg.meridians": "Meridians",
 
   "key.cultivatereg.qi_sight": "Toggle Qi Sight",
-  "item.cultivatereg.spirit_stone": "Spirit Stone"
+  "item.cultivatereg.low_spirit_stone": "Low-Grade Spirit Stone",
+  "item.cultivatereg.spirit_stone": "Mid-Grade Spirit Stone",
+  "item.cultivatereg.high_spirit_stone": "High-Grade Spirit Stone",
+  "item.cultivatereg.top_spirit_stone": "Top-Grade Spirit Stone"
 
 
 }

--- a/main/resources/assets/cultivatereg/models/item/high_spirit_stone.json
+++ b/main/resources/assets/cultivatereg/models/item/high_spirit_stone.json
@@ -1,0 +1,4 @@
+{
+  "parent": "item/generated",
+  "textures": { "layer0": "cultivatereg:item/spirit_stone" }
+}

--- a/main/resources/assets/cultivatereg/models/item/low_spirit_stone.json
+++ b/main/resources/assets/cultivatereg/models/item/low_spirit_stone.json
@@ -1,0 +1,4 @@
+{
+  "parent": "item/generated",
+  "textures": { "layer0": "cultivatereg:item/spirit_stone" }
+}

--- a/main/resources/assets/cultivatereg/models/item/top_spirit_stone.json
+++ b/main/resources/assets/cultivatereg/models/item/top_spirit_stone.json
@@ -1,0 +1,4 @@
+{
+  "parent": "item/generated",
+  "textures": { "layer0": "cultivatereg:item/spirit_stone" }
+}

--- a/main/resources/data/cultivatereg/loot_modifiers/spirit_stone_from_hostiles.json
+++ b/main/resources/data/cultivatereg/loot_modifiers/spirit_stone_from_hostiles.json
@@ -8,5 +8,9 @@
     },
     { "condition": "minecraft:random_chance_with_looting", "chance": 0.20, "looting_multiplier": 0.06 }
   ],
-  "stack": { "id": "cultivatereg:spirit_stone", "Count": 1 }
+  "low": { "item": "cultivatereg:low_spirit_stone", "count": 1 },
+  "mid": { "item": "cultivatereg:spirit_stone", "count": 1 },
+  "high": { "item": "cultivatereg:high_spirit_stone", "count": 1 },
+  "top": { "item": "cultivatereg:top_spirit_stone", "count": 1 },
+  "core_top_chance": 0.05
 }

--- a/main/resources/data/cultivatereg/recipes/high_to_mid_spirit_stone.json
+++ b/main/resources/data/cultivatereg/recipes/high_to_mid_spirit_stone.json
@@ -1,0 +1,7 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    { "item": "cultivatereg:high_spirit_stone" }
+  ],
+  "result": { "item": "cultivatereg:spirit_stone", "count": 9 }
+}

--- a/main/resources/data/cultivatereg/recipes/high_to_top_spirit_stone.json
+++ b/main/resources/data/cultivatereg/recipes/high_to_top_spirit_stone.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "SSS",
+    "SSS",
+    "SSS"
+  ],
+  "key": {
+    "S": { "item": "cultivatereg:high_spirit_stone" }
+  },
+  "result": { "item": "cultivatereg:top_spirit_stone" }
+}

--- a/main/resources/data/cultivatereg/recipes/low_to_mid_spirit_stone.json
+++ b/main/resources/data/cultivatereg/recipes/low_to_mid_spirit_stone.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "SSS",
+    "SSS",
+    "SSS"
+  ],
+  "key": {
+    "S": { "item": "cultivatereg:low_spirit_stone" }
+  },
+  "result": { "item": "cultivatereg:spirit_stone" }
+}

--- a/main/resources/data/cultivatereg/recipes/mid_to_high_spirit_stone.json
+++ b/main/resources/data/cultivatereg/recipes/mid_to_high_spirit_stone.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "SSS",
+    "SSS",
+    "SSS"
+  ],
+  "key": {
+    "S": { "item": "cultivatereg:spirit_stone" }
+  },
+  "result": { "item": "cultivatereg:high_spirit_stone" }
+}

--- a/main/resources/data/cultivatereg/recipes/mid_to_low_spirit_stone.json
+++ b/main/resources/data/cultivatereg/recipes/mid_to_low_spirit_stone.json
@@ -1,0 +1,7 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    { "item": "cultivatereg:spirit_stone" }
+  ],
+  "result": { "item": "cultivatereg:low_spirit_stone", "count": 9 }
+}

--- a/main/resources/data/cultivatereg/recipes/top_to_high_spirit_stone.json
+++ b/main/resources/data/cultivatereg/recipes/top_to_high_spirit_stone.json
@@ -1,0 +1,7 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    { "item": "cultivatereg:top_spirit_stone" }
+  ],
+  "result": { "item": "cultivatereg:high_spirit_stone", "count": 9 }
+}


### PR DESCRIPTION
## Summary
- add dedicated low, mid, high, and top grade spirit stone items with client-side tinting
- update the spirit stone loot modifier to drop tiers based on mob cultivation data and allow rare top-grade drops
- provide crafting recipes to convert between stone tiers and adjust meditating costs to consume low-grade stones

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d75ea7926c832fb6146a4421e73b26